### PR TITLE
Async method - rename topics

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -3,6 +3,7 @@ import { Card, Button } from "semantic-ui-react";
 import factory from "../ethereum/votingFactory";
 import Layout from "../components/Layout";
 import { Link } from "../routes";
+import Voting from "../ethereum/voting";
 
 class VotingIndex extends Component {
   static async getInitialProps() {
@@ -12,6 +13,11 @@ class VotingIndex extends Component {
   }
   renderVotings() {
     const items = this.props.votings.map((address) => {
+      let voting = Voting(address);
+      voting.methods.getSummary().call().then((summary) => {
+        console.log(summary[1]);
+      });
+
       return {
         header: address,
         description: (


### PR DESCRIPTION
Implements #4 

While we want to assign the value from summary[1] as the topic, the page shows an empty string, it's related to the asynchronous method that waits for the getSummary() function to be called, which contains, for example, the name of the topic.

I need an interesting opinion on this